### PR TITLE
fix: add support for asgi 3.0 while maintaining 2.0 support.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-source = asgi_middleware
+source = asgi_cors_middleware
 
 [report]
 exclude_lines =
@@ -20,5 +20,6 @@ omit =
     setup.py
     */distutils/*
     tests/*
+    asgi_cors_middleware/__init__.py
 
 show_missing = True

--- a/asgi_cors_middleware/middleware.py
+++ b/asgi_cors_middleware/middleware.py
@@ -10,6 +10,7 @@ import typing
 from starlette.datastructures import Headers, MutableHeaders
 
 from starlette.responses import PlainTextResponse
+from starlette.responses import Response
 
 # OPTIONS doesn't make sense to return as an allowed method for CORS.
 # See https://stackoverflow.com/a/68529748
@@ -121,7 +122,7 @@ class CorsASGIApp:
 
         return any(host in origin for host in self.origins)
 
-    def preflight_response(self, request_headers) -> PlainTextResponse:
+    def preflight_response(self, request_headers) -> Response:
         requested_origin = request_headers["origin"]
         requested_method = request_headers["access-control-request-method"]
         requested_headers = request_headers.get(
@@ -154,7 +155,7 @@ class CorsASGIApp:
                 failure_text, status_code=400, headers=headers
             )
 
-        return PlainTextResponse("OK", status_code=200, headers=headers)
+        return Response("", status_code=204, headers=headers)
 
     async def simple_response(
             self,

--- a/asgi_cors_middleware/middleware.py
+++ b/asgi_cors_middleware/middleware.py
@@ -52,7 +52,7 @@ class CorsASGIApp:
         preflight_headers = {}
         if "*" in origins:
             preflight_headers["Access-Control-Allow-Origin"] = "*"
-        else:
+        elif len(origins) > 1 or compiled_allow_origin_regex is not None:
             preflight_headers["Vary"] = "Origin"
         preflight_headers.update(
             {
@@ -186,5 +186,6 @@ class CorsASGIApp:
         elif not self.allow_all_origins and \
                 self.is_allowed_origin(origin=origin):
             headers["Access-Control-Allow-Origin"] = origin
-            headers.add_vary_header("Origin")
+            if len(self.origins) > 1 or self.allow_origin_regex is not None:
+                headers.add_vary_header("Origin")
         await send(message)

--- a/asgi_cors_middleware/middleware.py
+++ b/asgi_cors_middleware/middleware.py
@@ -95,10 +95,14 @@ class CorsASGIApp:
         if origin is None:
             return await self.call_app(scope, receive, send)
 
-        if method == "OPTIONS" and "access-control-request-method" in headers:
-            response = self.preflight_response(request_headers=headers)
-            await response(scope, receive, send)
-            return
+        if method == "OPTIONS":
+            if "access-control-request-method" in headers:
+                response = self.preflight_response(request_headers=headers)
+                await response(scope, receive, send)
+                return
+            # if this is an options request but was not a cors preflight,
+            #  we should skip the simple response processing.
+            return await self.call_app(scope, receive, send)
 
         await self.simple_response(
             scope, receive, send, request_headers=headers

--- a/asgi_cors_middleware/middleware.py
+++ b/asgi_cors_middleware/middleware.py
@@ -152,7 +152,7 @@ class CorsASGIApp:
         if failures:
             failure_text = "Disallowed CORS " + ", ".join(failures)
             return PlainTextResponse(
-                failure_text, status_code=400, headers=headers
+                failure_text, status_code=403, headers=headers
             )
 
         return Response("", status_code=204, headers=headers)

--- a/asgi_cors_middleware/middleware.py
+++ b/asgi_cors_middleware/middleware.py
@@ -11,7 +11,9 @@ from starlette.datastructures import Headers, MutableHeaders
 
 from starlette.responses import PlainTextResponse
 
-ALL_METHODS = ("DELETE", "GET", "OPTIONS", "PATCH", "POST", "PUT")
+# OPTIONS doesn't make sense to return as an allowed method for CORS.
+# See https://stackoverflow.com/a/68529748
+ALL_METHODS = ("DELETE", "GET", "PATCH", "POST", "PUT")
 SAFELISTED_HEADERS = {
     "Accept", "Accept-Language", "Content-Language", "Content-Type"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asgiref==3.3.4
+asgiref==3.7.2
 coverage==5.5
 pytest==6.2.4
 pytest-cov==2.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ twine==3.4.1
 wheel==0.36.2
 pytest-asyncio==0.15.1
 setuptools==56.2.0
+channels>=3.0.4,<4.0.0

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
     ],
     packages=["asgi_cors_middleware"],
     include_package_data=True,
-    install_requires=["starlette"]
+    install_requires=["starlette", "asgiref>=3.5.0"]
 )

--- a/tests/asgi_app.py
+++ b/tests/asgi_app.py
@@ -1,3 +1,4 @@
+
 async def app(scope, receive, send):
     if scope["type"] == "websocket":
         await send({"type": "websocket.accept"})
@@ -55,3 +56,9 @@ async def app(scope, receive, send):
         'type': 'http.response.body',
         'body': b'Internal Server Error',
     })
+
+class ASGI2app():
+    def __init__(self, scope):
+        self.scope = scope
+    async def __call__(self, receive, send):
+        return await app(self.scope, receive, send)

--- a/tests/asgi_app.py
+++ b/tests/asgi_app.py
@@ -1,12 +1,57 @@
-from starlette.applications import Starlette
-from starlette.responses import JSONResponse
-from starlette.routing import Route
-
-
-async def homepage(request):
-    return JSONResponse({'hello': 'world'})
-
-
-app = Starlette(debug=True, routes=[
-    Route('/', homepage),
-])
+async def app(scope, receive, send):
+    if scope["type"] == "websocket":
+        await send({"type": "websocket.accept"})
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.disconnect":
+                break
+            elif message["type"] == "websocket.receive":
+                # echo
+                await send({
+                    "type": "websocket.send",
+                    "text": message["text"],
+                })
+        return
+    elif scope['type'] == 'http':
+        is_get = scope['method'] == 'GET'
+        is_options = scope['method'] == 'OPTIONS'
+        is_homepage = scope['path'] == '/'
+        if is_get and is_homepage:
+            await send({
+                'type': 'http.response.start',
+                'status': 200,
+                'headers': [
+                    (b'content-length', b'17'),
+                    (b'content-type', b'application/json'),
+                ],
+            })
+            await send({
+                'type': 'http.response.body',
+                'body': b'{"hello":"world"}',
+            })
+            return
+        elif is_options and is_homepage:
+            await send({
+                'type': 'http.response.start',
+                'status': 200,
+                'headers': [
+                    (b'allow', b'GET, OPTIONS'),
+                    (b'content-length', b'2'),
+                ],
+            })
+            await send({
+                'type': 'http.response.body',
+                'body': b'OK',
+            })
+            return
+    await send({
+        'type': 'http.response.start',
+        'status': 500,
+        'headers': [
+            (b'content-type', b'text/plain'),
+        ],
+    })
+    await send({
+        'type': 'http.response.body',
+        'body': b'Internal Server Error',
+    })

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,98 +1,769 @@
 import pytest
 from asgiref.testing import ApplicationCommunicator as HttpCommunicator
-from asgi_cors_middleware import CorsASGIApp
+from channels.testing import WebsocketCommunicator
+
+from asgi_cors_middleware.middleware import CorsASGIApp
 from .asgi_app import app
 
 
-@pytest.mark.asyncio
-async def test_init_app():
+REQUEST_METHOD = b"access-control-request-method"
+REQUEST_HEADERS = b"access-control-request-headers"
+ALLOW_ORIGIN = b"access-control-allow-origin"
+ALLOW_METHODS = b"access-control-allow-methods"
+ALLOW_HEADERS = b"access-control-allow-headers"
+EXPOSE_HEADERS = b"access-control-expose-headers"
+MAX_AGE = b"access-control-max-age"
+
+
+async def do_cors_response(scope, expected_output, cors_options):
+    scope["type"] = "http"
+    scope["path"] = "/"
     communicator = HttpCommunicator(
-        scope={"type": "http", "http_version": "1.0", "method": "GET", "path": "/"},
-        application=app
+        scope=scope,
+        application=CorsASGIApp(app=app, **cors_options),
     )
     await communicator.send_input({"type": "http.request"})
-    output = await communicator.receive_output(1)
-    assert output == {
-        'type': 'http.response.start',
-        'status': 200,
-        'headers': [
-            (b'content-length', b'17'),
-            (b'content-type', b'application/json')
-        ]}
-    output = await communicator.receive_output(1)
-    assert output == {
-        'type': 'http.response.body',
-        'body': b'{"hello":"world"}'
+    response_start = await communicator.receive_output()
+    response_body = await communicator.receive_output()
+    assert response_start["type"] == "http.response.start"
+    assert response_start["status"] == expected_output["status"]
+    assert set(response_start["headers"]) == set(expected_output["headers"])
+    assert response_body == {
+        "type": "http.response.body",
+        "body": expected_output["body"],
     }
 
 
 @pytest.mark.asyncio
-async def test_whitelist_origin():
-    cors_app = CorsASGIApp(
-        app=app,
-        origins=["www.example.com"]
+class TestOrigins:
+    @pytest.mark.parametrize(
+        "request_headers, options_origins, expected_headers",
+        [
+            (
+                [(b"origin", b"http://e.com")],
+                ["*"],
+                [(ALLOW_ORIGIN, b"*")],
+            ),
+            (
+                [
+                    (b"origin", b"http://e.com"),
+                    (b"cookie", b"session=1234")
+                ],
+                ["*"],
+                [(ALLOW_ORIGIN, b"http://e.com")],
+            ),
+            (
+                [(b"origin", b"http://e.org")],
+                ["http://e.edu", "http://e.org"],
+                [
+                    (ALLOW_ORIGIN, b"http://e.org"),
+                    (b"vary", b"Origin"),
+                ],
+            ),
+            (
+                [(b"origin", b"http://e.net")],
+                ["http://e.net"],
+                [(ALLOW_ORIGIN, b"http://e.net")],
+            ),
+            (
+                [(b"origin", b"http://e.com")],
+                ["http://e.edu", "http://e.org"],
+                [],
+            ),
+            (
+                [(b"origin", b"http://e.com")],
+                ["http://e.net"],
+                [],
+            ),
+        ],
+        ids=[
+            "wildcard",
+            "wildcard_cookies",
+            "multiple",
+            "single",
+            "disallowed_multiple",
+            "disallowed_single",
+        ],
     )
-    scope = {
-        "type": "http",
-        "path": "/",
-        "method": "OPTIONS",
-        "headers": [
-            (b"origin", b"http://www.example.com"),
-            (b"access-control-request-method", b"post")
-        ]
-    }
-    communicator = HttpCommunicator(application=cors_app, scope=scope)
-    await communicator.send_input(
-        {
-            "type": "http",
-            "method": "options",
-            "headers": [
-                [b"content-type", b"text/plain"],
-                [b"access-control-request-method", b"post"],
-                [b"origin", b"example.com"]
-            ]
+    async def test_simple_response(
+        self, request_headers, options_origins, expected_headers
+    ):
+        await do_cors_response(
+            scope={
+                "method": "GET",
+                "headers": request_headers,
+            },
+            expected_output={
+                "status": 200,
+                "headers": expected_headers
+                + [
+                    (b"content-length", b"17"),
+                    (b"content-type", b"application/json"),
+                ],
+                "body": b'{"hello":"world"}',
+            },
+            cors_options={"origins": options_origins},
+        )
+
+    @pytest.mark.parametrize(
+        "from_origin, options_origins, expected_headers, options_status, body",
+        [
+            (
+                b"http://e.com",
+                ["*"],
+                [(ALLOW_METHODS, b"GET"), (MAX_AGE, b"600"), (ALLOW_ORIGIN, b"*")],
+                204,
+                b"",
+            ),
+            (
+                b"http://e.org",
+                ["http://e.edu", "http://e.org"],
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_ORIGIN, b"http://e.org"),
+                    (b"vary", b"Origin"),
+                ],
+                204,
+                b"",
+            ),
+            (
+                b"http://e.net",
+                ["http://e.net"],
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_ORIGIN, b"http://e.net"),
+                ],
+                204,
+                b"",
+            ),
+            (
+                b"http://e.com",
+                ["http://e.edu", "http://e.org"],
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (MAX_AGE, b"600"),
+                    (b"vary", b"Origin"),
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"content-length", b"22"),
+                ],
+                403,
+                b"Disallowed CORS origin",
+            ),
+            (
+                b"http://e.com",
+                ["http://e.net"],
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (MAX_AGE, b"600"),
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"content-length", b"22"),
+                ],
+                403,
+                b"Disallowed CORS origin",
+            ),
+        ],
+        ids=[
+            "wildcard",
+            "multiple",
+            "single",
+            "disallowed_multiple",
+            "disallowed_single",
+        ],
+    )
+    async def test_preflight_response(
+        self, from_origin, options_origins, expected_headers, options_status, body
+    ):
+        await do_cors_response(
+            scope={
+                "method": "OPTIONS",
+                "headers": [
+                    (REQUEST_METHOD, b"GET"),
+                    (b"origin", from_origin),
+                ],
+            },
+            expected_output={
+                "status": options_status,
+                "headers": expected_headers,
+                "body": body,
+            },
+            cors_options={"origins": options_origins},
+        )
+
+    @pytest.mark.asyncio
+    async def test_simple_response_with_regex_allowed_origins(self):
+        cors_options = {
+            "allow_origin_regex": r"http://e\..*",
+            "allow_methods": ["PATCH"],
         }
-    )
-    output = await communicator.receive_output(timeout=1)
-    assert (b'access-control-allow-origin', b'http://www.example.com') in \
-           output["headers"]
+        await do_cors_response(
+            scope={
+                "method": "GET",
+                "headers": [
+                    (b"origin", b"http://e.com"),
+                    (REQUEST_METHOD, b"PATCH"),
+                ],
+            },
+            expected_output={
+                "status": 200,
+                "headers": [
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (b"vary", b"Origin"),
+                    (b"content-length", b"17"),
+                    (b"content-type", b"application/json"),
+                ],
+                "body": b'{"hello":"world"}',
+            },
+            cors_options=cors_options,
+        )
+        await do_cors_response(
+            scope={
+                "method": "GET",
+                "headers": [
+                    (b"origin", b"http://f.net"),
+                    (REQUEST_METHOD, b"POST"),
+                ],
+            },
+            expected_output={
+                "status": 200,
+                "headers": [
+                    # no cors headers
+                    (b"content-length", b"17"),
+                    (b"content-type", b"application/json"),
+                ],
+                "body": b'{"hello":"world"}',
+            },
+            cors_options=cors_options,
+        )
+
+    @pytest.mark.asyncio
+    async def test_preflight_response_with_regex_allowed_origins(self):
+        cors_options = {
+            "allow_origin_regex": r"http://e\..*",
+            "allow_methods": ["PATCH"],
+        }
+        await do_cors_response(
+            scope={
+                "method": "OPTIONS",
+                "headers": [
+                    (b"origin", b"http://e.com"),
+                    (REQUEST_METHOD, b"PATCH"),
+                ],
+            },
+            expected_output={
+                "status": 204,
+                "headers": [
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (ALLOW_METHODS, b"PATCH"),
+                    (MAX_AGE, b"600"),
+                    (b"vary", b"Origin"),
+                ],
+                "body": b"",
+            },
+            cors_options=cors_options,
+        )
+        await do_cors_response(
+            scope={
+                "method": "OPTIONS",
+                "headers": [
+                    (b"origin", b"http://f.org"),
+                    (REQUEST_METHOD, b"PATCH"),
+                ],
+            },
+            expected_output={
+                "status": 403,
+                "headers": [
+                    (ALLOW_METHODS, b"PATCH"),
+                    (MAX_AGE, b"600"),
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"content-length", b"22"),
+                    (b"vary", b"Origin"),
+                ],
+                "body": b"Disallowed CORS origin",
+            },
+            cors_options=cors_options,
+        )
+
+    async def test_simple_response_with_no_origin(self):
+        await do_cors_response(
+            scope={
+                "method": "GET",
+                "headers": [],
+            },
+            expected_output={
+                "status": 200,
+                "headers": [
+                    # no cors headers
+                    (b"content-length", b"17"),
+                    (b"content-type", b"application/json"),
+                ],
+                "body": b'{"hello":"world"}',
+            },
+            cors_options={
+                "origins": ["http://e.com"],
+            },
+        )
+
+    async def test_preflight_response_with_no_origin(self):
+        # if you don't provide the origin header, this isn't a valid cors preflight request.
+        # we should get a regular options response
+        await do_cors_response(
+            scope={
+                "method": "OPTIONS",
+                "headers": [(REQUEST_METHOD, b"GET")],
+            },
+            expected_output={
+                "status": 200,
+                "headers": [
+                    (b"content-length", b"2"),
+                    (b"allow", b"GET, OPTIONS"),
+                ],
+                "body": b"OK",
+            },
+            cors_options={"origins": ["*"], "allow_methods": ["GET"]},
+        )
 
 
 @pytest.mark.asyncio
-async def test_allow_all():
-    cors_app = CorsASGIApp(
-        app=app,
-        origins=["*"]
+class TestAllowMethods:
+    @pytest.mark.parametrize(
+        "allow_methods",
+        [["*"], ["GET", "POST"], ["GET"]],
+        ids=[
+            "wildcard",
+            "multiple",
+            "single",
+        ],
     )
-    scope = {
-        "type": "http",
-        "path": "/",
-        "method": "OPTIONS",
-        "headers": [
-            (b"origin", b"http://www.example.com"),
-            (b"access-control-request-method", b"post")
-        ]
-    }
+    async def test_simple_response(self, allow_methods):
+        await do_cors_response(
+            scope={
+                "method": "GET",
+                "headers": [(b"origin", b"http://e.com")],
+            },
+            expected_output={
+                "status": 200,
+                "headers": [
+                    # allow methods is not included in simple responses
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (b"content-length", b"17"),
+                    (b"content-type", b"application/json"),
+                ],
+                "body": b'{"hello":"world"}',
+            },
+            cors_options={
+                "origins": ["http://e.com"],
+                "allow_methods": allow_methods,
+            },
+        )
 
-    communicator = HttpCommunicator(
-        application=cors_app,
-        scope=scope
+    @pytest.mark.parametrize(
+        "requested_headers, options_status, expected_headers, body, allow_methods",
+        [
+            (
+                [],
+                200,
+                [(b"allow", b"GET, OPTIONS"), (b"content-length", b"2")],
+                b"OK",
+                ["*"],
+            ),
+            (
+                [],
+                200,
+                [(b"allow", b"GET, OPTIONS"), (b"content-length", b"2")],
+                b"OK",
+                ["GET", "POST"],
+            ),
+            (
+                [],
+                200,
+                [(b"allow", b"GET, OPTIONS"), (b"content-length", b"2")],
+                b"OK",
+                ["GET"],
+            ),
+            (
+                [(REQUEST_METHOD, b"GET")],
+                204,
+                [
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_METHODS, b"DELETE, GET, PATCH, POST, PUT"),
+                ],
+                b"",
+                ["*"],
+            ),
+            (
+                [(REQUEST_METHOD, b"GET")],
+                204,
+                [
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_METHODS, b"GET, POST"),
+                ],
+                b"",
+                ["GET", "POST"],
+            ),
+            (
+                [(REQUEST_METHOD, b"GET")],
+                204,
+                [
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_METHODS, b"GET"),
+                ],
+                b"",
+                ["GET"],
+            ),
+            (
+                [(REQUEST_METHOD, b"GET")],
+                403,
+                [
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_METHODS, b"POST"),
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"content-length", b"22"),
+                ],
+                b"Disallowed CORS method",
+                ["POST"],
+            ),
+            (
+                [(REQUEST_METHOD, b"GET")],
+                403,
+                [
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_METHODS, b"POST, PUT"),
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"content-length", b"22"),
+                ],
+                b"Disallowed CORS method",
+                ["POST", "PUT"],
+            ),
+        ],
+        ids=[
+            "wildcard",
+            "multiple",
+            "single",
+            "requested_wildcard",
+            "requested_multiple",
+            "requested_single",
+            "disallowed_multiple",
+            "disallowed_single",
+        ],
     )
-    await communicator.send_input(
-        {
-            "type": "http",
-            "method": "options",
+    async def test_preflight_response(
+        self, requested_headers, options_status, expected_headers, body, allow_methods
+    ):
+        await do_cors_response(
+            scope={
+                "method": "OPTIONS",
+                "headers": requested_headers
+                + [
+                    (b"origin", b"http://e.com"),
+                ],
+            },
+            expected_output={
+                "status": options_status,
+                "headers": expected_headers,
+                "body": body,
+            },
+            cors_options={
+                "origins": ["http://e.com"],
+                "allow_methods": allow_methods,
+            },
+        )
+
+
+@pytest.mark.asyncio
+class TestAllowHeaders:
+    @pytest.mark.parametrize(
+        "allow_headers",
+        [["*"], ["GET", "POST"], ["GET"]],
+        ids=[
+            "wildcard",
+            "multiple",
+            "single",
+        ],
+    )
+    async def test_simple_response(self, allow_headers):
+        await do_cors_response(
+            scope={
+                "method": "GET",
+                "headers": [(b"origin", b"http://e.com")],
+            },
+            expected_output={
+                "status": 200,
+                "headers": [
+                    # allow headers is not included in simple responses
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (b"content-length", b"17"),
+                    (b"content-type", b"application/json"),
+                ],
+                "body": b'{"hello":"world"}',
+            },
+            cors_options={
+                "origins": ["http://e.com"],
+                "allow_headers": allow_headers,
+            },
+        )
+
+    @pytest.mark.parametrize(
+        "request_headers, options_status, expected_headers, body, allow_headers",
+        [
+            (
+                [],
+                204,
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                ],
+                b"",
+                ["*"],
+            ),
+            (
+                [],
+                204,
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_HEADERS, b"X-Header1, X-Header2"),
+                ],
+                b"",
+                ["X-Header1", "X-Header2"],
+            ),
+            (
+                [],
+                204,
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_HEADERS, b"X-Header1"),
+                ],
+                b"",
+                ["X-Header1"],
+            ),
+            (
+                [(REQUEST_HEADERS, b"X-Header1")],
+                204,
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_HEADERS, b"X-Header1"),
+                ],
+                b"",
+                ["*"],
+            ),
+            (
+                [(REQUEST_HEADERS, b"X-Header1")],
+                204,
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_HEADERS, b"X-Header1, X-Header2"),
+                ],
+                b"",
+                ["X-Header1", "X-Header2"],
+            ),
+            (
+                [(REQUEST_HEADERS, b"X-Header1")],
+                204,
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_HEADERS, b"X-Header1"),
+                ],
+                b"",
+                ["X-Header1"],
+            ),
+            (
+                [(REQUEST_HEADERS, b"X-Header3")],
+                403,
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_HEADERS, b"X-Header1, X-Header2"),
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"content-length", b"23"),
+                ],
+                b"Disallowed CORS headers",
+                ["X-Header1", "X-Header2"],
+            ),
+            (
+                [(REQUEST_HEADERS, b"X-Header3")],
+                403,
+                [
+                    (ALLOW_METHODS, b"GET"),
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (MAX_AGE, b"600"),
+                    (ALLOW_HEADERS, b"X-Header1"),
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"content-length", b"23"),
+                ],
+                b"Disallowed CORS headers",
+                ["X-Header1"],
+            ),
+        ],
+        ids=[
+            "wildcard",
+            "multiple",
+            "single",
+            "requested_wildcard",
+            "requested_multiple",
+            "requested_single",
+            "disallowed_multiple",
+            "disallowed_single",
+        ],
+    )
+    async def test_preflight_response(
+        self, request_headers, options_status, expected_headers, body, allow_headers
+    ):
+        headers_by_status = [] if options_status == 204 else []
+        await do_cors_response(
+            scope={
+                "method": "OPTIONS",
+                "headers": request_headers
+                + [
+                    (REQUEST_METHOD, b"GET"),
+                    (b"origin", b"http://e.com"),
+                ],
+            },
+            expected_output={
+                "status": options_status,
+                "headers": expected_headers + headers_by_status,
+                "body": body,
+            },
+            cors_options={
+                "origins": ["http://e.com"],
+                "allow_headers": allow_headers,
+            },
+        )
+
+
+@pytest.mark.asyncio
+class TestExposeHeaders:
+    async def test_simple_response(self):
+        await do_cors_response(
+            scope={
+                "method": "GET",
+                "headers": [
+                    (b"origin", b"http://e.com"),
+                    (REQUEST_METHOD, b"GET"),
+                ],
+            },
+            expected_output={
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", b"17"),
+                    (EXPOSE_HEADERS, b"X-Exposed, X-Exposed2"),
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                ],
+                "body": b'{"hello":"world"}',
+            },
+            cors_options={
+                "origins": ["http://e.com"],
+                "expose_headers": ["X-Exposed", "X-Exposed2"],
+            },
+        )
+
+    async def test_preflight_response(self):
+        await do_cors_response(
+            scope={
+                "method": "OPTIONS",
+                "headers": [
+                    (b"origin", b"http://e.com"),
+                    (REQUEST_METHOD, b"GET"),
+                ],
+            },
+            expected_output={
+                "status": 204,
+                "headers": [
+                    # expose headers are simple response only
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (ALLOW_METHODS, b"GET"),
+                    (MAX_AGE, b"600"),
+                ],
+                "body": b"",
+            },
+            cors_options={
+                "origins": ["http://e.com"],
+                "expose_headers": ["X-Exposed", "X-Exposed2"],
+            },
+        )
+
+
+@pytest.mark.asyncio
+class TestAllowCredentials:
+    async def test_preflight_response_with_allow_credentials(self):
+        await do_cors_response(
+            scope={
+                "method": "OPTIONS",
+                "headers": [
+                    (b"origin", b"http://e.com"),
+                    (REQUEST_METHOD, b"GET"),
+                ],
+            },
+            expected_output={
+                "status": 204,
+                "headers": [
+                    (ALLOW_ORIGIN, b"http://e.com"),
+                    (ALLOW_METHODS, b"GET"),
+                    (b"access-control-allow-credentials", b"true"),
+                    (MAX_AGE, b"600"),
+                ],
+                "body": b"",
+            },
+            cors_options={
+                "origins": ["http://e.com"],
+                "allow_credentials": True,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_preflight_response_with_custom_max_age():
+    await do_cors_response(
+        scope={
+            "method": "OPTIONS",
             "headers": [
-                [b"content-type", b"text/plain"],
-                [b"access-control-request-method", b"post"],
-                [b"origin", b"example.com"]
-            ]
-        }
+                (b"origin", b"http://e.com"),
+                (REQUEST_METHOD, b"GET"),
+            ],
+        },
+        expected_output={
+            "status": 204,
+            "headers": [
+                (ALLOW_ORIGIN, b"http://e.com"),
+                (ALLOW_METHODS, b"GET"),
+                (MAX_AGE, b"6000"),
+            ],
+            "body": b"",
+        },
+        cors_options={
+            "origins": ["http://e.com"],
+            "max_age": 6000,
+        },
     )
-    output = await communicator.receive_output(timeout=1)
-    assert (b'access-control-allow-origin', b'*') in output["headers"]
 
 
-@pytest.fixture
-def decorated_app():
-    return CorsASGIApp(app=app, origins=["localhost"])
+@pytest.mark.asyncio
+async def test_non_http_scope():
+    cors_app = CorsASGIApp(app=app, origins=["*"])
+    communicator = WebsocketCommunicator(application=cors_app, path="/")
+    try:
+        connected, _subprotocol = await communicator.connect()
+        assert connected
+        await communicator.send_json_to({"hello": "world"})
+        response = await communicator.receive_json_from()
+        assert response == {"hello": "world"}
+    finally:
+        await communicator.disconnect()


### PR DESCRIPTION
I encountered an issue where the ASGI app I was wrapping did not return a handler. In ASGI 3.0, this is expected. While writing tests for that change, I found other fixes or tweaks I would like to see and ended up with a test suite that included those.

This pull request is more extensive than I intended, so my apologies for that. Taking a pull request that rewrites so much can be annoying, so I would understand if you only wanted to take parts of this pull request.

This pull request makes the following changes:
* Use `asgiref` to do ASGI 3.0 and ASGI 2.0 compatibility.
* `OPTIONS` does not make sense as an allowed method in the context of CORS.
  See https://stackoverflow.com/a/68529748
  * exclude `OPTIONS` from all methods
  * exclude non-CORS `OPTIONS` requests from CORS headers.
* Do not always return safelisted headers. The inclusion of safelisted headers means skipping additional browser restrictions. See https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_request_header#additional_restrictions
* Return `204` for successful preflight responses and `403` for unsuccessful responses.
* Only provide `vary: Origin` header when multiple enumerated origins are valid.
* Expanded test coverage.
